### PR TITLE
feat: allow style set via environment variable

### DIFF
--- a/internal/handler/gemini_query.go
+++ b/internal/handler/gemini_query.go
@@ -20,10 +20,7 @@ var _ MessageHandler = (*GeminiQuery)(nil)
 
 // NewGeminiQuery returns a new GeminiQuery message handler.
 func NewGeminiQuery(io *IO, session *gemini.ChatSession, opts RendererOptions) (*GeminiQuery, error) {
-	renderer, err := glamour.NewTermRenderer(
-		glamour.WithStylePath(opts.StylePath),
-		glamour.WithWordWrap(opts.WordWrap),
-	)
+	renderer, err := opts.newTermRenderer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate terminal renderer: %w", err)
 	}

--- a/internal/handler/help_command.go
+++ b/internal/handler/help_command.go
@@ -18,10 +18,7 @@ var _ MessageHandler = (*HelpCommand)(nil)
 
 // NewHelpCommand returns a new HelpCommand.
 func NewHelpCommand(io *IO, opts RendererOptions) (*HelpCommand, error) {
-	renderer, err := glamour.NewTermRenderer(
-		glamour.WithStylePath(opts.StylePath),
-		glamour.WithWordWrap(opts.WordWrap),
-	)
+	renderer, err := opts.newTermRenderer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate terminal renderer: %w", err)
 	}

--- a/internal/handler/renderer_options.go
+++ b/internal/handler/renderer_options.go
@@ -1,7 +1,28 @@
 package handler
 
+import (
+	"os"
+
+	"github.com/charmbracelet/glamour"
+)
+
 // RendererOptions represents configuration options for the terminal renderer.
 type RendererOptions struct {
 	StylePath string
 	WordWrap  int
+}
+
+func (o RendererOptions) newTermRenderer() (*glamour.TermRenderer, error) {
+	var styleOption glamour.TermRendererOption
+	switch {
+	case o.StylePath == "auto" && os.Getenv("GLAMOUR_STYLE") != "":
+		styleOption = glamour.WithEnvironmentConfig()
+	default:
+		styleOption = glamour.WithStylePath(o.StylePath)
+	}
+
+	return glamour.NewTermRenderer(
+		styleOption,
+		glamour.WithWordWrap(o.WordWrap),
+	)
 }


### PR DESCRIPTION
Allow the Glamour style to be set by using its standard environment variable, `$GLAMOUR_STYLE`.  This allows all Glamour-using apps (such as GitHub CLI app) to share a style specification by setting a variable in the user's shell profile.  Furthermore, it allows `gemini-cli` to use a style without needing to repeatedly specify `--style=` on the command line.

The argument can be a predefined style name or the path to a json style file, as interpreted by Glamour's `WithEnvironmentConfig()`.

Fixes #42
